### PR TITLE
Prevent Symfony VarExporter LogicException: cannot generate lazy ghost

### DIFF
--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -91,7 +91,11 @@ abstract class Media implements MediaInterface
         return $this->versions;
     }
 
-    public function __get($id): ?MediaVersionInterface
+    /**
+     * @return ?MediaVersionInterface
+     * @throws InvalidArgumentException
+     */
+    public function __get($id)
     {
         if (!str_starts_with($id, 'version_')) {
             throw new InvalidArgumentException("Property $id not found");


### PR DESCRIPTION
```
Symfony\Component\VarExporter\Exception\LogicException: Cannot generate lazy ghost: return type of method "Softspring\MediaBundle\Entity\Media::__get()" should be "mixed".:

at .Doctrine\ORM\Proxy\ProxyFactory->generateUseLazyGhostTrait ( /workspace/vendor/symfony/var-exporter/ProxyHelper.php:43 )
at .Doctrine\ORM\Proxy\ProxyFactory->generateProxyClass ( /workspace/vendor/doctrine/orm/src/Proxy/ProxyFactory.php:537 )
at .Doctrine\ORM\Proxy\ProxyFactory->generateProxyClasses ( /workspace/vendor/doctrine/orm/src/Proxy/ProxyFactory.php:241 )
at .Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer->warmUp ( /workspace/vendor/symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php:60 )
at .Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp ( /workspace/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php:108 )
at .Symfony\Component\HttpKernel\Kernel->initializeContainer ( /workspace/vendor/symfony/http-kernel/Kernel.php:545 )
at .Symfony\Component\HttpKernel\Kernel->preBoot ( /workspace/vendor/symfony/http-kernel/Kernel.php:763 )
at .Symfony\Component\HttpKernel\Kernel->handle ( /workspace/vendor/symfony/http-kernel/Kernel.php:185 )
at .Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run ( /workspace/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35 )
at .require_once ( /workspace/vendor/autoload_runtime.php:29 )
at .{main} ( /workspace/public/index.php:8 )
```